### PR TITLE
appveyor CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on: [ push, pull_request ]
+
+jobs:
+
+  build:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        build_configuration: [ Release, Debug ]
+        build_platform: [ x64, Win32 ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow --tags
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.0
+
+      - name: Show MSBuild version
+        run: msbuild -version
+
+      - name: Run MSBuild
+        run: msbuild IndentByFold.vcxproj /m /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: plugin_dll_(${{ matrix.build_platform }})_(${{ matrix.build_configuration }})
+          path: ${{ matrix.build_platform }}/${{ matrix.build_configuration }}/IndentByFold.dll

--- a/IndentByFold.vcxproj
+++ b/IndentByFold.vcxproj
@@ -101,6 +101,7 @@
       </PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -126,6 +127,7 @@
       </PrecompiledHeaderFile>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -149,6 +151,7 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -173,6 +176,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,69 @@
+version: 0.7.2.{build}
+image: Visual Studio 2019
+
+
+environment:
+  matrix:
+    - PlatformToolset: v142
+
+platform:
+    - x64
+    - Win32
+
+configuration:
+    - Release
+    - Debug
+
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x64" set platform_input=x64
+
+    - if "%platform%"=="Win32" set archi=x86
+    - if "%platform%"=="Win32" set platform_input=Win32
+
+    - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild IndentByFold.sln /m /p:configuration="%configuration%" /p:platform="%platform_input%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+
+        if ($env:PLATFORM_INPUT -eq "x64") {
+            #Push-AppveyorArtifact "$env:PLATFORM_INPUT\$env:CONFIGURATION\IndentByFold.dll" -FileName IndentByFold.dll
+        }
+
+        if ($env:PLATFORM_INPUT -eq "Win32" ) {
+            #Push-AppveyorArtifact "$env:PLATFORM_INPUT\$env:CONFIGURATION\IndentByFold.dll" -FileName IndentByFold.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v142") {
+            if($env:PLATFORM_INPUT -eq "x64"){
+                $ZipFileName = "IndentByFold_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+                7z a $ZipFileName $env:PLATFORM_INPUT\$env:CONFIGURATION\IndentByFold.dll
+            }
+            if($env:PLATFORM_INPUT -eq "Win32"){
+                $ZipFileName = "IndentByFold_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+                7z a $ZipFileName $env:PLATFORM_INPUT\$env:CONFIGURATION\IndentByFold.dll
+            }
+        }
+
+artifacts:
+  - path: IndentByFold_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v142
+        configuration: Release

--- a/version_git.sh
+++ b/version_git.sh
@@ -21,7 +21,7 @@ function create_version_git_h()
 
 	# Get the version info from git
 	echo "Retrieving version information from git..."
-	VERSION=$(git describe --tags --abbrev=0 | grep -oP '\d+\.\d+\.\d+')
+	VERSION=$(git describe --tags --abbrev=0 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
 	VERSION_NUMBERS=$(echo $VERSION | tr "." ","),0
 	GIT_VERSION=$(git describe --tags --match 'v[0-9]*')
 	YEAR=$(date +%Y)


### PR DESCRIPTION
- initial appveyor.yml CI config to check the VS2015 build configuration
- removed unneeded props
- added multiprocessor build option

, see https://ci.appveyor.com/project/chcg/indentbyfold/build/0.7.1.4, could also be used to automatically deploy releases on tagging, see prepared section:

deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!

similar possibility exists also for travis, see e.g.

https://github.com/ashkulz/NppFTP/blob/master/.travis.yml